### PR TITLE
feat(prod-mode): added production and development mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@
 node_modules
 app/__build/
 app/__typings/
-handout/*.html
+npm-debug.log

--- a/README.md
+++ b/README.md
@@ -4,21 +4,25 @@ This is the initial version of our starter project using Angular 1.x, TypeScript
 
 ## Commands
 
+
 * `npm install`: install npm dependencies specified in package.json as well as typings specified in tsd.json (typings will be put into *app/__typings* folder which is also git ignored).
+* `postinstall`: runs automatically after `npm install` and triggers a `npm run build` to provide a build directory to `npm start` by default
+
+* `npm run dev`: will start webpack's development server (with live reloading) on [http://localhost:8080](http://localhost:8080). Note that in this case the bundle will be generated in memory and your bundle in *app/__build* might get out of sync.
+* `npm start`: starts a production server serving the *app/__build* directory on [http://localhost:3000](http://localhost:3000)
+
 * `npm run build`: bundle all of the application including js/css/html files, with index.html generated according to a template specified in *app/index.html* (Everything will be put into *app/__build* folder).
-* `npm start`: will start webpack's development server (with live reloading) on *localhost:8080*. Note that in this case the bundle will be generated in memory and your bundle in *app/__build* might get out of sync.
-* `npm run clean`: removes the bundle generated in *app/__build* directory
 * `npm test`: will run the unit tests for the project as specified in *karma.conf.js* (everything ending in .test.ts will ge picked up, refer to *app/src/tests.entry.ts* if other extensions should be used).
 * `npm run e2e`: will run the e2e suite for this project located in *app/e2e* (refer to *wdio.conf.js* and *gulpfile.js* for more info, this is the only `gulp` dependency).
 * `npm run typings`: removes existing typings located in *app/__typings* directory, reinstalls them based on *tsd.json*, and linkes whatever is available in *node_modules* (using `tsd link`).
 
 ## Improvements
 
-This is an initial version of this setup and will be expanded in the future. Refer to the issues section to see what need to be done, or create a new one.
+This is an initial version of this setup and will be expanded in the future. Refer to the [issues section](https://github.com/rangle/ng-typescript-webpack-starter/issues) to see what needs to be done, or create a [new one](https://github.com/rangle/ng-typescript-webpack-starter/issues/new).
 
 ## If something doesn't work
 
-Refer to the issues section to see if this has already been logged. Otherwise create a new issue.
+Refer to the [issues section](https://github.com/rangle/ng-typescript-webpack-starter/issues) to see if this has already been logged. Otherwise create a [new issue](https://github.com/rangle/ng-typescript-webpack-starter/issues/new).
 
 ## Example Application
 

--- a/package.json
+++ b/package.json
@@ -3,10 +3,14 @@
   "version": "1.0.0",
   "description": "Rangle's Angular/TypeScript/Webpack Starter Project",
   "license": "MIT",
+  "engines": {
+    "node": "4.x"
+  },
   "scripts": {
-    "postinstall": "npm run typings",
+    "postinstall": "npm run typings; npm run build;",
     "typings": "rimraf app/__typings && tsd install && tsd link",
-    "start": "webpack-dev-server --inline --colors --display-error-details --display-cached",
+    "dev": "NODE_ENV=development webpack-dev-server --display-error-details --display-cached",
+    "start": "NODE_ENV=production node server.js",
     "clean": "rimraf app/__build",
     "build": "npm run clean && webpack",
     "test": "karma start",
@@ -24,12 +28,15 @@
     "angular": "^1.4.7",
     "angular-ui-router": "^0.2.15",
     "basscss": "^7.0.4",
+    "chalk": "^1.1.1",
     "es6-shim": "^0.33.10",
+    "express": "^4.13.3",
     "font-awesome": "^4.4.0",
     "immutable": "^3.7.5",
     "koast-angular": "^0.2.2",
     "lodash-compat": "^3.10.1",
-    "rx": "4.0.0"
+    "rx": "4.0.0",
+    "winston": "^2.1.1"
   },
   "devDependencies": {
     "angular-mocks": "^1.4.7",

--- a/server.js
+++ b/server.js
@@ -1,0 +1,18 @@
+const express = require('express');
+const winston = require('winston');
+const chalk = require('chalk');
+
+const app = express();
+const PORT = process.env.PORT || 3000;
+const DOMAIN = '0.0.0.0';
+
+app.use('/', express.static('app/__build'));
+
+app.listen(PORT, (err) => {
+  if (err) {
+    winston.error(err);
+    return;
+  }
+
+  winston.info(`Listening at http://${ chalk.green(DOMAIN) }:${ chalk.yellow(PORT) }`);
+});

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,6 +1,30 @@
-var path = require("path");
-var webpack = require('webpack');
-var HtmlWebpackPlugin = require('html-webpack-plugin');
+'use strict';
+let path = require("path");
+let webpack = require('webpack');
+let HtmlWebpackPlugin = require('html-webpack-plugin');
+
+let basePlugins = [
+  new webpack.optimize.CommonsChunkPlugin('vendor', '[name].[hash].bundle.js'),
+  new HtmlWebpackPlugin({
+    template: './app/index.html',
+    inject: 'body',
+    minify: false
+  })
+];
+
+let devPlugins = [];
+
+let prodPlugins = [
+  new webpack.optimize.UglifyJsPlugin({
+    compress: {
+      warnings: false
+    }
+  })
+];
+
+const plugins = basePlugins
+  .concat(process.env.NODE_ENV === 'production' ? prodPlugins : [])
+  .concat(process.env.NODE_ENV === 'development' ? devPlugins : []);
 
 module.exports = {
   context: path.resolve(__dirname, 'app'),
@@ -38,15 +62,8 @@ module.exports = {
     extensions: ['', '.webpack.js', '.web.js', '.ts', '.js']
   },
   
-  plugins: [
-    new webpack.optimize.CommonsChunkPlugin('vendor', '[name].[hash].bundle.js'),
-    new HtmlWebpackPlugin({
-      template: './app/index.html',
-      inject: 'body',
-      minify: false
-    })
-  ],
-  
+  plugins: plugins,
+
   module: {
     preLoaders: [{
       test: /\.ts$/,


### PR DESCRIPTION
modified - `npm start` to set node env production. this is incomplete at this point as we need to discuss http-server vs manually written express 

created - `npm dev` which sets node env to development

modified webpack.conf.js to only uglify in production mode. 

tested: 
a build with `npm dev` takes 8 seconds
a build with `npm start` takes 16 seconds